### PR TITLE
Expose TMDB Class to Package

### DIFF
--- a/tmdb/__init__.py
+++ b/tmdb/__init__.py
@@ -1,0 +1,1 @@
+from .tmdb import TMDB


### PR DESCRIPTION
Without exposing the TMDB class to the package, the current usage instructions are incorrect:

```
>>> from tmdb import TMDB
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ImportError: cannot import name 'TMDB' from 'tmdb'
```

One would instead:

```
>>> from tmdb.tmdb import TMDB
>>> tmdb = TMDB()
```